### PR TITLE
Fixed bug

### DIFF
--- a/double-metaphone.cabal
+++ b/double-metaphone.cabal
@@ -1,5 +1,5 @@
 name:           double-metaphone
-version:        0.0.1
+version:        0.0.2
 license:        GPL
 license-file:   LICENSE
 homepage:       https://github.com/christian-marie/double-metaphone
@@ -13,7 +13,7 @@ synopsis:       Haskell bindings to a C double-metaphone implementation.
 cabal-version:  >= 1.8
 build-type:     Simple
 description:
-	
+
 	Compute two metaphones of a latin1 encoded bytestring, based on Perl's text-DoubleMetaphone
 
 extra-source-files:

--- a/lib/Language/Phonetic/DoubleMetaphone.hs
+++ b/lib/Language/Phonetic/DoubleMetaphone.hs
@@ -51,8 +51,8 @@ doubleMetaphone
     :: ByteString
     -- ^ The input string, should be Latin-1 or Char7 encoded.
     -> (ByteString, ByteString)
-doubleMetaphone = doubleMetaphoneBounded maxBound
-
+doubleMetaphone = doubleMetaphoneBounded cIntMaxBound
+  where cIntMaxBound = fromIntegral (maxBound :: CInt)
 foreign import ccall unsafe "double-metaphones.h DoubleMetaphone"
     c_double_metaphone
         :: CString


### PR DESCRIPTION
The `doubleMetaphone` function was returning ("",""). `doubleMetaphoneBounded` seemed to work.
Tracked down the problem to the max that you were passing in `maxBound :: Int` not `maxBound :: CInt`
